### PR TITLE
download dependencies automatically and cleanup .gitignore

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="var" path="wpilib" sourcepath="wpilib.sources"/>
+	<classpathentry exported="true" kind="var" path="networktables" sourcepath="networktables.sources"/>
+	<classpathentry exported="true" kind="var" path="opencv" sourcepath="opencv.sources"/>
+	<classpathentry exported="true" kind="var" path="cscore" sourcepath="cscore.sources"/>
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry exported="true" kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
+	<classpathentry exported="true" kind="lib" path="libs/CTRE_Phoenix-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/CTRE_Phoenix.jar"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
-	<classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
-	<classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
-	<classpathentry kind="lib" path="/Users/dmitry/wpilib/java/current/lib/CTRE_Phoenix-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="/Users/dmitry/wpilib/java/current/lib/CTRE_Phoenix.jar">
-		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="/Users/dmitry/wpilib/java/current/lib/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix-sources.jar"/>
-	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,19 @@
-/bin/
-*.jar
-*.class
-*.jar
+# ignore build artifacts
+bin/
+dist/
+build/
 
-*.jar
-/dist/
-/build/
-*.class
+# ignore dependencies
+libs/
+
+# ignore MacOS stuff
+**/.DS_Store
+
+# ignore IntelliJ configuration
+*.iml
+.idea/
+
+# ignore Jetson training cache
 *.tensorcache
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Environment Setup
+
+We've included an Ant file, `download-libs.xml`, that will download the required dependencies for you. Run this first.
+
+## Build and Deployment
+
+Use `build.xml` to deploy to your roboRio.

--- a/build.properties
+++ b/build.properties
@@ -2,3 +2,12 @@
 package=org.usfirst.frc.team5700.robot
 robot.class=${package}.Robot
 simulation.world.file=/usr/share/frcsim/worlds/GearsBotDemo.world
+team-number=5700
+
+# Properties needed to support CTRE and WPI in libs/
+userLibs.dir=libs/
+wpilib=libs/wpilib/java/${version}
+wpilib.common=libs/wpilib/common/${version}
+
+# Place to actually download all the libs
+libsArchive.url=https://s3-us-west-1.amazonaws.com/frc5700/java-dependencies/Archive.zip

--- a/build.xml
+++ b/build.xml
@@ -21,10 +21,10 @@
 
   <!-- Any other property in build.properties can also be overridden. -->
 
-  <property file="${user.home}/wpilib/wpilib.properties"/>
+  <property file="libs/wpilib/wpilib.properties"/>
   <property file="build.properties"/>
-  <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>
+  <property file="libs/wpilib/java/current/ant/build.properties"/>
 
-  <import file="${wpilib.ant.dir}/build.xml"/>
+  <import file="libs/wpilib/java/current/ant/build.xml"/>
 
 </project>

--- a/download-libs.xml
+++ b/download-libs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="FRC 5700 download dependencies" default="download">
+    <property file="build.properties"/>
+
+	<target name="download">
+		<mkdir dir="libs/"/>
+		<get src="${libsArchive.url}" dest="libs/Archive.zip" verbose="true"/>
+		<unzip src="libs/Archive.zip" dest="libs/"/>
+	</target>
+</project>


### PR DESCRIPTION
Hi SoftDev! I wrote a bit of infrastructure that I would suggest including, to make the environment setup easier.

There's a new file, `download-libs.xml`, that downloads WPI and CTRE dependencies (latest version) that I've packaged up and hosted for you at my personal S3. We can move them elsewhere if you like. They get put into a libs/ folder in the project.

Second, there's modifications to the `build.xml` that allow the deployment process to use those dependencies.

Finally, I've cleaned up and commented your `.gitignore` file to ignore those new dependency files and for easier reading. There's some documentation in your README about how to use all this, but it should be expanded.

@madelinebelew @renatavolch whenever you have some time, we should go over these and you should try it out yourself.